### PR TITLE
Fixed the type mismatch

### DIFF
--- a/src/odrive_can_node.cpp
+++ b/src/odrive_can_node.cpp
@@ -41,7 +41,7 @@ ODriveCanNode::ODriveCanNode(const std::string& node_name) : rclcpp::Node(node_n
     subscriber_ = rclcpp::Node::create_subscription<ControlMessage>("control_message", ctrl_msg_qos, std::bind(&ODriveCanNode::subscriber_callback, this, _1));
 
     rclcpp::QoS srv_qos(rclcpp::KeepAll{});
-    service_ = rclcpp::Node::create_service<AxisState>("request_axis_state", std::bind(&ODriveCanNode::service_callback, this, _1, _2), srv_qos);
+    service_ = rclcpp::Node::create_service<AxisState>("request_axis_state", std::bind(&ODriveCanNode::service_callback, this, _1, _2), srv_qos.get_rmw_qos_profile());
 }
 
 void ODriveCanNode::deinit() {


### PR DESCRIPTION
This is a fix for the type mismatch in the expected type of the third argument in the `create_service` function. This is specifically for the LTS ROS 2 Humble Hawksbill distribution. 